### PR TITLE
Fix HTTPS proxy detection with ProxyFix middleware

### DIFF
--- a/app.py
+++ b/app.py
@@ -20,6 +20,7 @@ import torch
 from dotenv import load_dotenv
 from flask import Flask, jsonify, request, send_file
 from flask_cors import CORS
+from werkzeug.middleware.proxy_fix import ProxyFix
 from loguru import logger
 from PIL import Image, UnidentifiedImageError
 
@@ -172,6 +173,17 @@ queue_lock = threading.Lock()
 app = Flask(__name__)
 app.config.from_object(Config)
 CORS(app)  # Enable Cross-Origin Resource Sharing
+
+# Configure ProxyFix to handle proxy headers correctly
+# This tells Flask to trust proxy headers for HTTPS detection
+app.wsgi_app = ProxyFix(
+    app.wsgi_app,
+    x_for=1,      # Trust 1 proxy for X-Forwarded-For
+    x_proto=1,    # Trust 1 proxy for X-Forwarded-Proto (http/https)
+    x_host=1,     # Trust 1 proxy for X-Forwarded-Host
+    x_prefix=1    # Trust 1 proxy for X-Forwarded-Prefix
+)
+
 # The default Flask logger is now intercepted by Loguru, so no app-specific setup is needed.
 
 


### PR DESCRIPTION
## Summary
- Added Werkzeug ProxyFix middleware to handle proxy headers correctly
- Fixes mixed content errors when running behind HTTPS reverse proxy
- App now properly detects HTTPS protocol and generates correct URLs

## Test plan
- [x] Verified ProxyFix correctly handles X-Forwarded-Proto headers
- [x] Tested that /config endpoint returns HTTPS URLs when behind proxy
- [x] Confirmed mixed content errors are resolved